### PR TITLE
Update 02-compute-resources.md

### DIFF
--- a/docs/02-compute-resources.md
+++ b/docs/02-compute-resources.md
@@ -28,7 +28,7 @@ This does the below:
     | master-2     | kubernetes-ha-master-2 | Master        | 192.168.5.12 |     2712         |
     | worker-1     | kubernetes-ha-worker-1 | Worker        | 192.168.5.21 |     2730         |
     | worker-2     | kubernetes-ha-worker-2 | Worker        | 192.168.5.22 |     2721         |
-    | lb           | kubernetes-ha-lb       | LoadBalancer  | 192.168.5.30 |     2722         |
+    | loadbalancer | kubernetes-ha-lb       | LoadBalancer  | 192.168.5.30 |     2722         |
 
     > These are the default settings. These can be changed in the Vagrant file
 


### PR DESCRIPTION
Under the VM column, for "lb", the vagrant script actually names it "loadbalancer" not "lb".